### PR TITLE
카카오 로그아웃 기능 연결, HomeFragment Keyword API 한번만 호출되도록 수정

### DIFF
--- a/app/src/main/java/com/sesac/planet/config/PlanetApplication.kt
+++ b/app/src/main/java/com/sesac/planet/config/PlanetApplication.kt
@@ -47,6 +47,10 @@ class PlanetApplication : Application() {
             } ?: return false
         }
 
+        fun getLoginType(): Int {
+            return sharedPreferences.getInt(Constant.LOGIN_TYPE, -1)
+        }
+
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/sesac/planet/presentation/view/main/my_page/MyPageFragment.kt
+++ b/app/src/main/java/com/sesac/planet/presentation/view/main/my_page/MyPageFragment.kt
@@ -5,8 +5,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.content.edit
 import androidx.fragment.app.Fragment
+import com.google.android.material.snackbar.Snackbar
+import com.kakao.sdk.user.UserApiClient
+import com.sesac.planet.config.PlanetApplication
 import com.sesac.planet.databinding.FragmentMyPageBinding
+import com.sesac.planet.utility.Constant
 import com.sesac.planet.utility.SystemUtility
 
 class MyPageFragment : Fragment()  {
@@ -25,7 +31,7 @@ class MyPageFragment : Fragment()  {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         SystemUtility.applyWindowInsetsTopPadding(binding.root)
-
+        initialize()
         /*
         binding.myPageReportLayout.setOnClickListener {
             val intent = Intent(requireContext(), ReportActivity::class.java)
@@ -33,6 +39,38 @@ class MyPageFragment : Fragment()  {
         }
 
          */
+
+
+    }
+
+    private fun initialize() {
+        initViews()
+    }
+
+    private fun initViews() {
+        binding.myPageLogoutBtn.setOnClickListener {
+            if(PlanetApplication.isLoginUser()) {
+                when (PlanetApplication.getLoginType()) {
+                    Constant.KAKAO_LOGIN -> {
+                        UserApiClient.instance.logout {
+                            PlanetApplication.sharedPreferences.edit {
+                                putString(Constant.X_ACCESS_TOKEN, null)
+                                putInt(Constant.USER_ID, -1)
+                                putInt(Constant.LOGIN_TYPE, -1)
+                                Snackbar.make(binding.root, "로그아웃에 성공했습니다.", Snackbar.LENGTH_SHORT).show()
+
+                            }
+                        }
+                    }
+                    Constant.EMAIL_LOGIN -> {
+
+                    }
+                    else -> {
+
+                    }
+                }
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/sesac/planet/presentation/view/splash/LoadingSplashActivity.kt
+++ b/app/src/main/java/com/sesac/planet/presentation/view/splash/LoadingSplashActivity.kt
@@ -43,9 +43,9 @@ class LoadingSplashActivity : AppCompatActivity() {
             CoroutineScope(Dispatchers.Main).launch {
                 delay(Constant.SPLASH_ANIMATION_MILLIS)
                 //ToDO
-                //startActivity(Intent(this@LoadingSplashActivity, LoginActivity::class.java))
+                startActivity(Intent(this@LoadingSplashActivity, LoginActivity::class.java))
                 //startActivity(Intent(this@SplashActivity, MakePlanningActivity::class.java))
-                startActivity(Intent(this@LoadingSplashActivity, MainActivity::class.java))
+                //startActivity(Intent(this@LoadingSplashActivity, MainActivity::class.java))
                 finish()
             }
         }

--- a/app/src/main/java/com/sesac/planet/presentation/viewmodel/main/KeywordViewModel.kt
+++ b/app/src/main/java/com/sesac/planet/presentation/viewmodel/main/KeywordViewModel.kt
@@ -1,5 +1,6 @@
 package com.sesac.planet.presentation.viewmodel.main
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -12,18 +13,21 @@ import com.sesac.planet.network.KeywordAPI
 import kotlinx.coroutines.launch
 import retrofit2.Response
 
-class KeywordViewModel(private val getKeywordUseCase: GetKeywordUseCase): ViewModel() {
+class KeywordViewModel(private val getKeywordUseCase: GetKeywordUseCase) : ViewModel() {
     private val _keywordData = MutableLiveData<Response<KeywordResponse>>()
     val keywordData: LiveData<Response<KeywordResponse>> get() = _keywordData
 
     init {
-        KeywordRepository.keywordService = PlanetApplication.getInstance().create(KeywordAPI::class.java)
+        KeywordRepository.keywordService =
+            PlanetApplication.getInstance().create(KeywordAPI::class.java)
     }
 
-    fun getKeyword(token: String, journeyId: Int){
-        viewModelScope.launch {
-            val response = getKeywordUseCase(token, journeyId)
-            _keywordData.value = response
+    fun getKeyword(token: String, journeyId: Int) {
+        if (_keywordData.value == null) {
+            viewModelScope.launch {
+                val response = getKeywordUseCase(token, journeyId)
+                _keywordData.value = response
+            }
         }
     }
 }


### PR DESCRIPTION
1. 카카오 로그아웃 기능 구현
2. MainActivity 의 BottomNavigationView 를 통해 이동할 때 HomeFragment 의 상단에 노출되는 Keyword 를 가져오는 API 가 여러번 호출되는 문제 수정