### PR TITLE
View 수정 및 LoginActivity onStart 생명주기 로직 수정

### DIFF
--- a/app/src/main/java/com/sesac/planet/config/PlanetApplication.kt
+++ b/app/src/main/java/com/sesac/planet/config/PlanetApplication.kt
@@ -41,12 +41,15 @@ class PlanetApplication : Application() {
             return instance!!
         }
 
+
         fun isLoginUser(): Boolean {
             val jwt = sharedPreferences.getString(Constant.X_ACCESS_TOKEN, "")
             jwt?.let {
                 return it.isNotEmpty()
             } ?: return false
         }
+
+
 
         fun getLoginType(): Int {
             return sharedPreferences.getInt(Constant.LOGIN_TYPE, -1)

--- a/app/src/main/java/com/sesac/planet/presentation/view/login/LoginActivity.kt
+++ b/app/src/main/java/com/sesac/planet/presentation/view/login/LoginActivity.kt
@@ -9,6 +9,7 @@ import com.sesac.planet.config.PlanetApplication
 import com.sesac.planet.databinding.ActivityLoginBinding
 import com.sesac.planet.presentation.view.main.MainActivity
 import com.sesac.planet.presentation.view.settings.MakePlanningActivity
+import com.sesac.planet.utility.Constant
 import com.sesac.planet.utility.SystemUtility
 
 /*
@@ -47,8 +48,23 @@ class LoginActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
+        /*
         if(PlanetApplication.isLoginUser()) {
             startMainPage()
+        }
+
+         */
+
+        val userId = PlanetApplication.sharedPreferences.getInt(Constant.USER_ID, -1)
+        val jwt = PlanetApplication.sharedPreferences.getString(Constant.X_ACCESS_TOKEN, "")
+        val journeyId = PlanetApplication.sharedPreferences.getInt(Constant.JOURNEY_ID, -1)
+
+        jwt?.let { token ->
+            if(userId != -1 &&  token.isNotEmpty()) {
+                if(journeyId != -1) {
+                    startMainPage()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/sesac/planet/presentation/view/main/home/HomeAddToDoDialog.kt
+++ b/app/src/main/java/com/sesac/planet/presentation/view/main/home/HomeAddToDoDialog.kt
@@ -6,6 +6,7 @@ import android.graphics.Point
 import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -107,6 +108,7 @@ class HomeAddToDoDialog(private val onPostDetailPlan: OnPostDetailPlan) : Dialog
                 response.body()?.result.let { body ->
                     if(body == null){
                     } else{
+                        Log.d("PlanetTest", response.body()?.result.toString())
                         dialogSelectAdapter = DialogSelectAdapter(body, this)
                         binding.dialogHomeSelectPlanetRecycler.layoutManager =
                             LinearLayoutManager(requireContext(), RecyclerView.HORIZONTAL, false)

--- a/app/src/main/java/com/sesac/planet/presentation/view/settings/MakeNickNameFragment.kt
+++ b/app/src/main/java/com/sesac/planet/presentation/view/settings/MakeNickNameFragment.kt
@@ -1,11 +1,14 @@
 package com.sesac.planet.presentation.view.settings
 
+import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import android.view.inputmethod.InputMethod
+import android.view.inputmethod.InputMethodManager
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
@@ -37,7 +40,7 @@ class MakeNickNameFragment : Fragment() {
     }
 
     private fun initialize() {
-        SystemUtility.setSoftInputMode(requireActivity().window, WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        //SystemUtility.setSoftInputMode(requireActivity().window, WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
 
         initViews()
         initObservers()
@@ -51,6 +54,9 @@ class MakeNickNameFragment : Fragment() {
         }
 
         binding.checkThisNickNameButton.setOnClickListener {
+            val imm = requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.hideSoftInputFromWindow(binding.nickNameEditText.windowToken, 0)
+            binding.nickNameEditText.clearFocus()
             viewModel.checkNickName(binding.nickNameEditText.text.toString())
         }
     }

--- a/app/src/main/res/layout/fragment_my_future_look.xml
+++ b/app/src/main/res/layout/fragment_my_future_look.xml
@@ -130,6 +130,7 @@
                 app:layout_constraintStart_toStartOf="@id/my_future_look_header_first_line_text_view"
                 app:layout_constraintTop_toBottomOf="@id/my_future_look_title_text_view" />
 
+            <!--
             <EditText
                 android:id="@+id/add_future_look_edit_text"
                 android:layout_width="0dp"
@@ -154,6 +155,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/add_future_look_edit_text"
                 app:layout_constraintTop_toTopOf="@id/add_future_look_edit_text" />
+                -->
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
1. MyFutureLookFragment EditText 삭제
2. LoginActivity onStart 에서 로그인한 사용자를 구분할 때 jwt token, userId, journeyId 가 있을 경우 MainActivity 로 이동시키고
jwt token, userId 만 있을 경우에는 MakePlanningActivity 로 이동시키도록 수정(아직 여정을 만들지 않은 사용자라고 판단)